### PR TITLE
Cleanup the `relaton xml2html` interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 /spec/reports/
 /tmp/
 /.pryrc
+/.rubocop-https*
 
 .rspec_status

--- a/lib/relaton/cli/command.rb
+++ b/lib/relaton/cli/command.rb
@@ -111,16 +111,8 @@ module Relaton
 
       desc "xml2html RELATON-INDEX-XML STYLESHEET LIQUID-TEMPLATE-DIR", "Convert Relaton Collection XML into HTML"
 
-      def xml2html(filename, stylesheet, liquid_dir)
-        file = File.read(filename, encoding: "utf-8")
-        xml_to_html = Relaton::Cli::XmlToHtmlRenderer.new({
-          stylesheet: stylesheet,
-          liquid_dir: liquid_dir,
-        })
-        html_filename = Pathname.new(filename).sub_ext('.html')
-        File.open(html_filename, "w:UTF-8") do |f|
-          f.write(xml_to_html.render(file))
-        end
+      def xml2html(file, style, template)
+        Relaton::Cli::XMLConvertor.to_html(file, style, template)
       end
 
       desc "yaml2html YAML STYLESHEET LIQUID-TEMPLATE-DIR", "Concatenate Relaton YAML into HTML"

--- a/lib/relaton/cli/xml_convertor.rb
+++ b/lib/relaton/cli/xml_convertor.rb
@@ -8,8 +8,17 @@ module Relaton
         convert_and_write(file_content, :to_yaml)
       end
 
+      def to_html
+        content = convert_to_html
+        write_to_a_file(content)
+      end
+
       def self.to_yaml(file, options = {})
         new(file, options).to_yaml
+      end
+
+      def self.to_html(file, style, template)
+        new(file, style: style, template: template, extension: "html").to_html
       end
 
       private

--- a/lib/relaton/cli/xml_to_html_renderer.rb
+++ b/lib/relaton/cli/xml_to_html_renderer.rb
@@ -50,5 +50,8 @@ module Relaton::Cli
       uri.sub(/\.[^.]+$/, ".#{extension.to_s}")
     end
 
+    def self.render(file, options)
+      new(options).render(file)
+    end
   end
 end

--- a/spec/acceptance/relaton_xml2html_spec.rb
+++ b/spec/acceptance/relaton_xml2html_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "Relaton xml2html" do
+  describe "relaton xml2html" do
+    it "convers the xml file to xml" do
+      allow(Relaton::Cli::XMLConvertor).to receive(:to_html)
+      command = %w(xml2html sample.xml style.css templates)
+
+      Relaton::Cli.start(command)
+
+      expect(Relaton::Cli::XMLConvertor).to have_received(:to_html).
+        with("sample.xml", "style.css", "templates")
+    end
+  end
+end

--- a/spec/fixtures/collection.xml
+++ b/spec/fixtures/collection.xml
@@ -1,0 +1,636 @@
+<relaton-collection xmlns="https://open.ribose.com/relaton-xml"><title>CalConnect Standards Registry</title><relation type='partOf'><bibdata type='administrative'>
+<fetched>2018-10-31</fetched>
+<title>Membership -- Lifecycle management -- Part 1: Onboarding</title>
+<docidentifier>CC/Cor 12990-3</docidentifier>
+<uri>http://calconnect.org/pubdocs/CD0507%20CalDAV%20Use%20Cases%20V1.0.pdf</uri>
+<uri type='html'>csd/cc-cor-12990-3.html</uri>
+<uri type='pdf'>csd/cc-cor-12990-3.pdf</uri>
+<uri type='doc'>csd/cc-cor-12990-3.doc</uri>
+<uri type='relaton'>csd/cc-cor-12990-3.xml</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-09-26</on></date>
+<status>withdrawn</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='report'>
+<fetched>2018-10-31</fetched>
+<title>CalConnect XLIII -- Position on the European Union daylight-savings timezone change</title>
+<docidentifier>CC/R 3101</docidentifier>
+<uri>http://calconnect.org/pubdocs/CD0507%20CalDAV%20Use%20Cases%20V1.0.pdf</uri>
+<uri type='html'>csd/cc-r-3101.html</uri>
+<uri type='pdf'>csd/cc-r-3101.pdf</uri>
+<uri type='doc'>csd/cc-r-3101.doc</uri>
+<uri type='relaton'>csd/cc-r-3101.xml</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2019-10-17</on></date>
+<status>cancelled</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='governance'>
+<fetched>2018-10-31</fetched>
+<title>Standardization and publication</title>
+<docidentifier>CC/DIR 10001</docidentifier>
+<uri>standards/csd-standardization/csd-standardization.xml</uri>
+<uri type='html'>csd/cc-dir-10001.html</uri>
+<uri type='pdf'>csd/cc-dir-10001.pdf</uri>
+<uri type='doc'>csd/cc-dir-10001.doc</uri>
+<uri type='relaton'>csd/cc-dir-10001.xml</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-17</on></date>
+<status>proposal</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='governance'>
+<fetched>2018-10-31</fetched>
+<title>Standard document requirements</title>
+<docidentifier>CC/DIR 10002</docidentifier>
+<uri>standards/csd-document-requirements/csd-document-requirements.xml</uri>
+<uri type='html'>csd/cc-dir-10002.html</uri>
+<uri type='pdf'>csd/cc-dir-10002.pdf</uri>
+<uri type='doc'>csd/cc-dir-10002.doc</uri>
+<uri type='relaton'>csd/cc-dir-10002.xml</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-17</on></date>
+<status>proposal</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Representations for information interchange -- Part 1: Basic rules</title>
+<docidentifier>CC 18001</docidentifier>
+<uri>standards/csd-datetime-explict/csd-datetime-explict.xml</uri>
+<uri type='html'>csd/cc-18001.html</uri>
+<uri type='pdf'>csd/cc-18001.pdf</uri>
+<uri type='doc'>csd/cc-18001.doc</uri>
+<uri type='relaton'>csd/cc-18001.xml</uri>
+<language></language>
+<script></script>
+<date type='published'><on>2018-10-17</on></date>
+<status>Published</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='specification'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Calendars -- Gregorian calendar</title>
+<docidentifier>CC/S 50012</docidentifier>
+<uri>http://calconnect.org/pubdocs/CD0507%20CalDAV%20Use%20Cases%20V1.0.pdf</uri>
+<uri type='html'>csd/cc-s-50012.html</uri>
+<uri type='pdf'>csd/cc-s-50012.pdf</uri>
+<uri type='doc'>csd/cc-s-50012.doc</uri>
+<uri type='relaton'>csd/cc-s-50012.xml</uri>
+<language></language>
+<script></script>
+<date type='published'><on>2018-09-26</on></date>
+<status>Published</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='specification'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Timezone -- Timezone Management</title>
+<docidentifier>CC/Amd 86003</docidentifier>
+<uri>http://calconnect.org/pubdocs/CD0507%20CalDAV%20Use%20Cases%20V1.0.pdf</uri>
+<uri type='html'>csd/cc-amd-86003.html</uri>
+<uri type='pdf'>csd/cc-amd-86003.pdf</uri>
+<uri type='doc'>csd/cc-amd-86003.doc</uri>
+<uri type='relaton'>csd/cc-amd-86003.xml</uri>
+<language></language>
+<script></script>
+<date type='published'><on>2018-09-26</on></date>
+<status>Published</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='guide'>
+<fetched>2018-10-31</fetched>
+<title>Standardization -- Vocabulary</title>
+<docidentifier>CC/Guide 33000</docidentifier>
+<uri>standards/csd-standardization-vocabulary/csd-standardization-vocabulary.xml</uri>
+<uri type='html'>csd/cc-guide-33000.html</uri>
+<uri type='pdf'>csd/cc-guide-33000.pdf</uri>
+<uri type='doc'>csd/cc-guide-33000.doc</uri>
+<uri type='relaton'>csd/cc-guide-33000.xml</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2004-09-25</on></date>
+<status>working-draft</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='specification'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Calendars -- Chinese calendar</title>
+<docidentifier>CC/S 34006</docidentifier>
+<uri type='relaton'>csd/ext-34006.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='governance'>
+<fetched>2018-10-31</fetched>
+<title>Standard document requirements</title>
+<docidentifier>CC/DIR 10002</docidentifier>
+<uri>standards/csd-document-requirements/csd-document-requirements.xml</uri>
+<uri type='xml'>csd/cc-dir-10002.xml</uri>
+<uri type='html'>csd/cc-dir-10002.html</uri>
+<uri type='pdf'>csd/cc-dir-10002.pdf</uri>
+<uri type='doc'>csd/cc-dir-10002.doc</uri>
+<uri type='relaton'>csd/cc-dir-10002.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-17</on></date>
+<status>proposal</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Codes for calendar systems</title>
+<docidentifier>CC 34003</docidentifier>
+<uri type='relaton'>csd/ext-cc-34003..rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Calendars -- Gregorian calendar</title>
+<docidentifier>CC 34005</docidentifier>
+<uri type='relaton'>csd/ext-34005.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='governance'>
+<fetched>2018-10-31</fetched>
+<title>Standardization and publication</title>
+<docidentifier>CC/DIR 10001</docidentifier>
+<uri>standards/csd-standardization/csd-standardization.xml</uri>
+<uri type='xml'>csd/cc-dir-10001.xml</uri>
+<uri type='html'>csd/cc-dir-10001.html</uri>
+<uri type='pdf'>csd/cc-dir-10001.pdf</uri>
+<uri type='doc'>csd/cc-dir-10001.doc</uri>
+<uri type='relaton'>csd/cc-dir-10001.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-17</on></date>
+<status>proposal</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Standardization documents -- Vocabulary</title>
+<docidentifier>CC 36000</docidentifier>
+<uri type='relaton'>csd/ext-36000.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>PUBLISH</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='report'>
+<fetched>2018-10-31</fetched>
+<title>Calendar operator practices — Guidelines to protect against calendar abuse</title>
+<docidentifier>CC/R/DS 18003</docidentifier>
+<uri type='xml'>csd/csd-calspam-bcp.xml</uri>
+<uri type='html'>csd/csd-calspam-bcp.html</uri>
+<uri type='pdf'>csd/csd-calspam-bcp.pdf</uri>
+<uri type='doc'>csd/csd-calspam-bcp.doc</uri>
+<uri type='relaton'>csd/csd-calspam-bcp.rxl</uri>
+<language>en</language>
+<script>Latn</script>
+<copyright><from>2018</from>
+<owner><organization><name>CalConnect</name></organization></owner>
+</copyright><contributor>
+<role type='author'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<contributor>
+<role type='publisher'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<language>en</language>
+<script>Latn</script>
+<status>draft-standard</status>
+<editorialgroup><technical-committee>CALSPAM</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Concepts and vocabulary</title>
+<docidentifier>CC 34000</docidentifier>
+<uri type='relaton'>csd/ext-34000.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='specification'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Timezone -- Timezone Management</title>
+<docidentifier>CC/Amd 86003</docidentifier>
+<uri>http://calconnect.org/pubdocs/CD0507%20CalDAV%20Use%20Cases%20V1.0.pdf</uri>
+<uri type='xml'>csd/cc-amd-86003.xml</uri>
+<uri type='html'>csd/cc-amd-86003.html</uri>
+<uri type='pdf'>csd/cc-amd-86003.pdf</uri>
+<uri type='doc'>csd/cc-amd-86003.doc</uri>
+<uri type='relaton'>csd/cc-amd-86003.rxl</uri>
+<language></language>
+<script></script>
+<date type='published'><on>2018-09-26</on></date>
+<status>Published</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Codes for calendar systems</title>
+<docidentifier>CC 34003</docidentifier>
+<uri type='relaton'>csd/ext-34003.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Timezones</title>
+<docidentifier>CC 34002</docidentifier>
+<uri type='relaton'>csd/ext-cc-34002..rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='specification'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Calendars -- Gregorian calendar</title>
+<docidentifier>CC/S 50012</docidentifier>
+<uri>http://calconnect.org/pubdocs/CD0507%20CalDAV%20Use%20Cases%20V1.0.pdf</uri>
+<uri type='xml'>csd/cc-s-50012.xml</uri>
+<uri type='html'>csd/cc-s-50012.html</uri>
+<uri type='pdf'>csd/cc-s-50012.pdf</uri>
+<uri type='doc'>csd/cc-s-50012.doc</uri>
+<uri type='relaton'>csd/cc-s-50012.rxl</uri>
+<language></language>
+<script></script>
+<date type='published'><on>2018-09-26</on></date>
+<status>Published</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Representations for information interchange -- Part 1: Basic rules</title>
+<docidentifier>CC 18001</docidentifier>
+<uri>standards/csd-datetime-explict/csd-datetime-explict.xml</uri>
+<uri type='xml'>csd/cc-18001.xml</uri>
+<uri type='html'>csd/cc-18001.html</uri>
+<uri type='pdf'>csd/cc-18001.pdf</uri>
+<uri type='doc'>csd/cc-18001.doc</uri>
+<uri type='relaton'>csd/cc-18001.rxl</uri>
+<language></language>
+<script></script>
+<date type='published'><on>2018-10-17</on></date>
+<status>Published</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Timezones</title>
+<docidentifier>CC 34002</docidentifier>
+<uri type='relaton'>csd/ext-34002.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='report'>
+<fetched>2018-10-31</fetched>
+<title>CalConnect XLIII -- Position on the European Union daylight-savings timezone change</title>
+<docidentifier>CC/R 3101</docidentifier>
+<uri>http://calconnect.org/pubdocs/CD0507%20CalDAV%20Use%20Cases%20V1.0.pdf</uri>
+<uri type='xml'>csd/cc-r-3101.xml</uri>
+<uri type='html'>csd/cc-r-3101.html</uri>
+<uri type='pdf'>csd/cc-r-3101.pdf</uri>
+<uri type='doc'>csd/cc-r-3101.doc</uri>
+<uri type='relaton'>csd/cc-r-3101.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2019-10-17</on></date>
+<status>cancelled</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='administrative'>
+<fetched>2018-10-31</fetched>
+<title>Membership -- Lifecycle management -- Part 1: Onboarding</title>
+<docidentifier>CC/Cor 12990-3</docidentifier>
+<uri>http://calconnect.org/pubdocs/CD0507%20CalDAV%20Use%20Cases%20V1.0.pdf</uri>
+<uri type='xml'>csd/cc-cor-12990-3.xml</uri>
+<uri type='html'>csd/cc-cor-12990-3.html</uri>
+<uri type='pdf'>csd/cc-cor-12990-3.pdf</uri>
+<uri type='doc'>csd/cc-cor-12990-3.doc</uri>
+<uri type='relaton'>csd/cc-cor-12990-3.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-09-26</on></date>
+<status>withdrawn</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='specification'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Calendars -- Chinese calendar</title>
+<docidentifier>CC/S 34006</docidentifier>
+<uri type='relaton'>csd/ext-cc-s-34006..rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Calendars -- Gregorian calendar</title>
+<docidentifier>CC 34005</docidentifier>
+<uri type='relaton'>csd/ext-cc-34005..rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>CalConnect Directive: Standard document requirements</title>
+<docidentifier>CC/DIR 10002</docidentifier>
+<uri type='xml'>csd/csd-document-requirements.xml</uri>
+<uri type='html'>csd/csd-document-requirements.html</uri>
+<uri type='pdf'>csd/csd-document-requirements.pdf</uri>
+<uri type='doc'>csd/csd-document-requirements.doc</uri>
+<uri type='relaton'>csd/csd-document-requirements.rxl</uri>
+<language>en</language>
+<script>Latn</script>
+<copyright><from>2018</from>
+<owner><organization><name>CalConnect</name></organization></owner>
+</copyright><contributor>
+<role type='author'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<contributor>
+<role type='publisher'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<language>en</language>
+<script>Latn</script>
+<status>draft</status>
+<editorialgroup><technical-committee>PUBLISH</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='advisory'>
+<fetched>2018-10-31</fetched>
+<title>CalConnect calls on EU to reconsider timeline for proposed seasonal time changes: Workshop and mailing list announced to discuss technical impact of planned changes</title>
+<docidentifier>CC/Adv/FDS 18018</docidentifier>
+<uri type='xml'>csd/csd-eu-dst-recommendation.xml</uri>
+<uri type='html'>csd/csd-eu-dst-recommendation.html</uri>
+<uri type='pdf'>csd/csd-eu-dst-recommendation.pdf</uri>
+<uri type='doc'>csd/csd-eu-dst-recommendation.doc</uri>
+<uri type='relaton'>csd/csd-eu-dst-recommendation.rxl</uri>
+<language>en</language>
+<script>Latn</script>
+<copyright><from>2018</from>
+<owner><organization><name>CalConnect</name></organization></owner>
+</copyright><contributor>
+<role type='author'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<contributor>
+<role type='publisher'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<language>en</language>
+<script>Latn</script>
+<status>final-draft</status>
+<editorialgroup><technical-committee>AdHoc EU Time</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Standardization documents -- Vocabulary</title>
+<docidentifier>CC 36000</docidentifier>
+<uri type='relaton'>csd/ext-cc-36000.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>PUBLISH</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Calendars -- Gregorian calendar</title>
+<docidentifier>CC 34005</docidentifier>
+<uri type='relaton'>csd/ext-cc-34005.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Standardization documents -- Vocabulary</title>
+<docidentifier>CC 36000</docidentifier>
+<uri type='relaton'>csd/ext-cc-36000..rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>PUBLISH</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Timezones</title>
+<docidentifier>CC 34002</docidentifier>
+<uri type='relaton'>csd/ext-cc-34002.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>CalConnect Directive: Standardization and publication</title>
+<docidentifier>CC/DIR 10001</docidentifier>
+<uri type='xml'>csd/csd-publication-process.xml</uri>
+<uri type='html'>csd/csd-publication-process.html</uri>
+<uri type='pdf'>csd/csd-publication-process.pdf</uri>
+<uri type='doc'>csd/csd-publication-process.doc</uri>
+<uri type='relaton'>csd/csd-publication-process.rxl</uri>
+<language>en</language>
+<script>Latn</script>
+<copyright><from>2018</from>
+<owner><organization><name>CalConnect</name></organization></owner>
+</copyright><contributor>
+<role type='author'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<contributor>
+<role type='publisher'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<language>en</language>
+<script>Latn</script>
+<status>draft</status>
+<editorialgroup><technical-committee>PUBLISH</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Codes for calendar systems</title>
+<docidentifier>CC 34003</docidentifier>
+<uri type='relaton'>csd/ext-cc-34003.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time — Explicit representation</title>
+<docidentifier>CC/WD 18011</docidentifier>
+<uri type='xml'>csd/csd-datetime-explicit.xml</uri>
+<uri type='html'>csd/csd-datetime-explicit.html</uri>
+<uri type='pdf'>csd/csd-datetime-explicit.pdf</uri>
+<uri type='doc'>csd/csd-datetime-explicit.doc</uri>
+<uri type='relaton'>csd/csd-datetime-explicit.rxl</uri>
+<language>en</language>
+<script>Latn</script>
+<copyright><from>2018</from>
+<owner><organization><name>CalConnect</name></organization></owner>
+</copyright><contributor>
+<role type='author'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<contributor>
+<role type='publisher'/>
+<organization><name>CalConnect</name></organization>
+</contributor>
+<language>en</language>
+<script>Latn</script>
+<status>working-draft</status>
+<editorialgroup><technical-committee>VCARD, CALENDAR</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Concepts and vocabulary</title>
+<docidentifier>CC 34000</docidentifier>
+<uri type='relaton'>csd/ext-cc-34000.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='guide'>
+<fetched>2018-10-31</fetched>
+<title>Standardization -- Vocabulary</title>
+<docidentifier>CC/Guide 33000</docidentifier>
+<uri>standards/csd-standardization-vocabulary/csd-standardization-vocabulary.xml</uri>
+<uri type='xml'>csd/cc-guide-33000.xml</uri>
+<uri type='html'>csd/cc-guide-33000.html</uri>
+<uri type='pdf'>csd/cc-guide-33000.pdf</uri>
+<uri type='doc'>csd/cc-guide-33000.doc</uri>
+<uri type='relaton'>csd/cc-guide-33000.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2004-09-25</on></date>
+<status>working-draft</status>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='specification'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Calendars -- Chinese calendar</title>
+<docidentifier>CC/S 34006</docidentifier>
+<uri type='relaton'>csd/ext-cc-s-34006.rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+<relation type='partOf'><bibdata type='standard'>
+<fetched>2018-10-31</fetched>
+<title>Date and time -- Concepts and vocabulary</title>
+<docidentifier>CC 34000</docidentifier>
+<uri type='relaton'>csd/ext-cc-34000..rxl</uri>
+<language></language>
+<script></script>
+<date type='updated'><on>2018-10-25</on></date>
+<language></language>
+<script></script>
+<status>proposal</status>
+<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
+</bibdata>
+</relation>
+</relaton-collection>

--- a/spec/relaton-cli_spec.rb
+++ b/spec/relaton-cli_spec.rb
@@ -25,17 +25,6 @@ RSpec.describe "extract", skip: true do
   end
 end
 
-RSpec.describe "xml2html", skip: true do
-  it "converts Relaton XML to HTML" do
-    FileUtils.rm_rf "spec/assets/collection.html"
-    system "relaton xml2html spec/assets/collection.xml spec/assets/index-style.css spec/assets/templates"
-    expect(File.exist?("spec/assets/collection.html")).to be true
-    html = File.read("spec/assets/collection.html", encoding: "utf-8")
-    expect(html).to include "I AM A SAMPLE STYLESHEET"
-    expect(html).to include %(<a href="csd/cc-r-3101.html">CalConnect XLIII -- Position on the European Union daylight-savings timezone change</a>)
-  end
-end
-
 RSpec.describe "yaml2html", skip: true do
   it "converts Relaton YAML to HTML" do
     FileUtils.rm_rf "spec/assets/relaton-yaml/collection.html"

--- a/spec/relaton/cli/xml_convertor_spec.rb
+++ b/spec/relaton/cli/xml_convertor_spec.rb
@@ -30,6 +30,25 @@ RSpec.describe Relaton::Cli::XMLConvertor do
     end
   end
 
+  describe ".to_html" do
+    context "with valid file and styles" do
+      it "sends render message to xml to html renderer" do
+        buffer = stub_file_write_to_io("spec/fixtures/collection.html", "html")
+
+        Relaton::Cli::XMLConvertor.to_html(
+          "spec/fixtures/collection.xml",
+          "spec/assets/index-style.css",
+          "spec/assets/templates",
+        )
+
+        expect(buffer).to include("I AM A SAMPLE STYLESHEET")
+        expect(buffer).to include("<!DOCTYPE HTML>\n<html>\n  <head>")
+        expect(buffer).to include("<title>CalConnect Standards Registry</tit")
+        expect(buffer).to include('<a href="csd/cc-r-3101.html">CalConnect ')
+      end
+    end
+  end
+
   def sample_collection_file
     @sample_collection_file ||= "spec/fixtures/sample-collection.xml"
   end


### PR DESCRIPTION
The `relaton xml2html` interface, is taking a file and then it's related styles and templates, and then it's using a renderer to generate the HTML and finally write it to a file.

But we actually do have a dedicated converter for XML, so now it makes more sense to encapsulate that behavior there and from the CLI all we need to do is invoke that interface and let our converter take care of the rest.