### PR TITLE
Add support to extract single file

### DIFF
--- a/lib/relaton/cli/command.rb
+++ b/lib/relaton/cli/command.rb
@@ -16,7 +16,7 @@ module Relaton
         io.puts(fetch_document(code, options) || supported_type_message)
       end
 
-      desc "extract Metanorma-XML-Directory Relaton-XML-Directory", "Extract Relaton XML from folder of Metanorma XML"
+      desc "extract Metanorma-XML-File / Directory Relaton-XML-Directory", "Extract Relaton XML from Metanorma XML file / directory"
       option :extension, aliases: :x, desc: "File extension of Relaton XML files, defaults to 'rxl'"
 
       def extract(source_dir, outdir)

--- a/lib/relaton/cli/relaton_file.rb
+++ b/lib/relaton/cli/relaton_file.rb
@@ -21,10 +21,11 @@ module Relaton
 
       # Extract files
       #
-      # This interface expect us to provide a source directory, output
-      # directory and custom configuration options. Then it wll extract
-      # Relaton XML files to output directory from the source directory
-      # During this process it will use custom options when available.
+      # This interface expect us to provide a source file / directory,
+      # output directory and custom configuration options. Then it wll
+      # extract Relaton XML file / files to output directory from the
+      # source file / directory. During this process it will use custom
+      # options when available.
       #
       # @param source [Dir] The source directory for files
       # @param outdir [Dir] The output directory for files
@@ -71,8 +72,16 @@ module Relaton
         Nokogiri.XML(document)
       end
 
+      def select_source_files
+        if File.file?(source)
+          [source]
+        else
+          select_files_with("xml")
+        end
+      end
+
       def extract_and_write_to_files
-        select_files_with("xml").each do |file|
+        select_source_files.each do |file|
           xml = nokogiri_document(nil, file)
           xml.remove_namespaces!
 

--- a/spec/relaton/cli/relaton_file_spec.rb
+++ b/spec/relaton/cli/relaton_file_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Relaton::Cli::RelatonFile do
 
         content = File.read("./tmp/output/a.rxl")
 
-        expect(file_exist?("CC-18002.rxl")).to be false
         expect(file_exist?("cc-amd-86003.rxl")).to be false
         expect(file_exist?("cc-cor-12990-3.rxl")).to be true
         expect(content).to include("<bibdata type='standard'>")
@@ -31,6 +30,20 @@ RSpec.describe Relaton::Cli::RelatonFile do
         expect(file_exist?("a.rxml")).to be true
         expect(file_exist?("cc-cor-12990-3.rxl")).to be false
         expect(file_exist?("cc-cor-12990-3.rxml")).to be true
+      end
+    end
+
+    context "with single Metanorma XML file" do
+      it "extracts the XML in the output directory" do
+        Relaton::Cli::RelatonFile.extract(
+          "spec/assets/metanorma-xml/a.xml", "./tmp/output"
+        )
+
+        content = File.read("./tmp/output/a.rxl")
+
+        expect(file_exist?("a.rxl")).to be_truthy
+        expect(file_exist?("cc-cor-12990-3.rxl")).to be_falsey
+        expect(content).to include("<bibdata type='standard'>")
       end
     end
   end


### PR DESCRIPTION
Currently, the `extract` interface is expecting us to provide a directory and then it select all of the files in that directory and extract the relaton file from those.

But this commit, add the support so this interface will not only works on directory but single files, and keep all other process same as before.

Fixes: #30