### PR TITLE
Add the `relaton split` interface

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "relaton/cli"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+require "pry"
+Pry.start

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -30,6 +30,16 @@ file), a link to that file is inserted.
 If the `TITLE` or `ORGANIZATION` options are given, they are added to the `Collection-File` output as the
 title and author of the `relaton-collection` document.
 
+=== relaton split
+
+[source,console]
+----
+$ relaton split Collection-File Relaton-File-Directory -x rxl
+----
+
+Splits a `Relaton-Collection-File` into multiple files in the `Relaton-File-Directory`, and it also
+suports an addional `extension` options to use different extension.
+
 === relaton fetch
 
 [source,console]

--- a/lib/relaton/cli/command.rb
+++ b/lib/relaton/cli/command.rb
@@ -31,6 +31,13 @@ module Relaton
         Relaton::Cli::RelatonFile.concatenate(source_dir, outfile, options)
       end
 
+      desc "split Relaton-Collection-File Relaton-XML-Directory", "Split a Relaton Collection into multiple files"
+      option :extension, aliases: :x, desc: "File extension of Relaton XML files, defaults to 'rxl'"
+
+      def split(source, outdir)
+        Relaton::Cli::RelatonFile.split(source, outdir, options)
+      end
+
       desc "yaml2xml YAML", "Convert Relaton YAML into Relaton Collection XML or separate files"
       option :extension, aliases: :x, desc: "File extension of Relaton XML files, defaults to 'rxl'"
       option :prefix, aliases: :p, desc: "Filename prefix of individual Relaton XML files, defaults to empty"

--- a/spec/acceptance/relaton_split_spec.rb
+++ b/spec/acceptance/relaton_split_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+RSpec.describe "Relaton Split" do
+  describe "relaton split"  do
+    it "sends the split message relaton file" do
+      allow(Relaton::Cli::RelatonFile).to receive(:split)
+      command = %w(split spec/fixtures/sample-collection.xml ./tmp -x xml)
+
+      Relaton::Cli.start(command)
+
+      expect(Relaton::Cli::RelatonFile).to have_received(:split).
+        with("spec/fixtures/sample-collection.xml", "./tmp", extension: "xml")
+    end
+  end
+end

--- a/spec/fixtures/sample-collection.xml
+++ b/spec/fixtures/sample-collection.xml
@@ -1,67 +1,105 @@
-<relaton-collection xmlns="https://open.ribose.com/relaton-xml"><title>CalConnect Standards Registry</title><contributor><role type='author'/><organization><name>The Calendaring and Scheduling Consortium</name></organization></contributor><relation type='partOf'><bibdata type='standard'>
-<fetched>2018-11-09</fetched>
-<title>Date and time -- Concepts and vocabulary</title>
-<docidentifier>CC 34000</docidentifier>
-<language></language>
-<script></script>
-<date type=''><on>2018-10-25</on></date>
-<status>proposal</status>
-<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
-</bibdata>
-</relation>
-<relation type='partOf'><bibdata type='standard'>
-<fetched>2018-11-09</fetched>
-<title>Date and time -- Timezones</title>
-<docidentifier>CC 34002</docidentifier>
-<language></language>
-<script></script>
-<date type=''><on>2018-10-25</on></date>
-<status>proposal</status>
-<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
-</bibdata>
-</relation>
-<relation type='partOf'><bibdata type='standard'>
-<fetched>2018-11-09</fetched>
-<title>Date and time -- Codes for calendar systems</title>
-<docidentifier>CC 34003</docidentifier>
-<language></language>
-<script></script>
-<date type=''><on>2018-10-25</on></date>
-<status>proposal</status>
-<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
-</bibdata>
-</relation>
-<relation type='partOf'><bibdata type='standard'>
-<fetched>2018-11-09</fetched>
-<title>Date and time -- Calendars -- Gregorian calendar</title>
-<docidentifier>CC 34005</docidentifier>
-<language></language>
-<script></script>
-<date type=''><on>2018-10-25</on></date>
-<status>proposal</status>
-<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
-</bibdata>
-</relation>
-<relation type='partOf'><bibdata type='specification'>
-<fetched>2018-11-09</fetched>
-<title>Date and time -- Calendars -- Chinese calendar</title>
-<docidentifier>CC/S 34006</docidentifier>
-<language></language>
-<script></script>
-<date type=''><on>2018-10-25</on></date>
-<status>proposal</status>
-<editorialgroup><technical-committee>DATETIME</technical-committee></editorialgroup>
-</bibdata>
-</relation>
-<relation type='partOf'><bibdata type='standard'>
-<fetched>2018-11-09</fetched>
-<title>Standardization documents -- Vocabulary</title>
-<docidentifier>CC 36000</docidentifier>
-<language></language>
-<script></script>
-<date type=''><on>2018-10-25</on></date>
-<status>proposal</status>
-<editorialgroup><technical-committee>PUBLISH</technical-committee></editorialgroup>
-</bibdata>
-</relation>
+<relaton-collection xmlns="https://open.ribose.com/relaton-xml">
+    <title>CalConnect Standards Registry</title>
+    <contributor>
+        <role type="author" />
+        <organization>
+            <name>The Calendaring and Scheduling Consortium</name>
+        </organization>
+    </contributor>
+    <relation type="partOf">
+        <bibdata type="standard">
+            <fetched>2018-11-09</fetched>
+            <title>Date and time -- Concepts and vocabulary</title>
+            <docidentifier>CC 34000</docidentifier>
+            <language></language>
+            <script></script>
+            <date type="">
+                <on>2018-10-25</on>
+            </date>
+            <status>proposal</status>
+            <editorialgroup>
+                <technical-committee>DATETIME</technical-committee>
+            </editorialgroup>
+        </bibdata>
+    </relation>
+    <relation type="partOf">
+        <bibdata type="standard">
+            <fetched>2018-11-09</fetched>
+            <title>Date and time -- Timezones</title>
+            <docidentifier>CC 34002</docidentifier>
+            <language></language>
+            <script></script>
+            <date type="">
+                <on>2018-10-25</on>
+            </date>
+            <status>proposal</status>
+            <editorialgroup>
+                <technical-committee>DATETIME</technical-committee>
+            </editorialgroup>
+        </bibdata>
+    </relation>
+    <relation type="partOf">
+        <bibdata type="standard">
+            <fetched>2018-11-09</fetched>
+            <title>Date and time -- Codes for calendar systems</title>
+            <docidentifier>CC 34003</docidentifier>
+            <language></language>
+            <script></script>
+            <date type="">
+                <on>2018-10-25</on>
+            </date>
+            <status>proposal</status>
+            <editorialgroup>
+                <technical-committee>DATETIME</technical-committee>
+            </editorialgroup>
+        </bibdata>
+    </relation>
+    <relation type="partOf">
+        <bibdata type="standard">
+            <fetched>2018-11-09</fetched>
+            <title>Date and time -- Calendars -- Gregorian calendar</title>
+            <docidentifier>CC 34005</docidentifier>
+            <language></language>
+            <script></script>
+            <date type="">
+                <on>2018-10-25</on>
+            </date>
+            <status>proposal</status>
+            <editorialgroup>
+                <technical-committee>DATETIME</technical-committee>
+            </editorialgroup>
+        </bibdata>
+    </relation>
+    <relation type="partOf">
+        <bibdata type="specification">
+            <fetched>2018-11-09</fetched>
+            <title>Date and time -- Calendars -- Chinese calendar</title>
+            <docidentifier>CC/S 34006</docidentifier>
+            <language></language>
+            <script></script>
+            <date type="">
+                <on>2018-10-25</on>
+            </date>
+            <status>proposal</status>
+            <editorialgroup>
+                <technical-committee>DATETIME</technical-committee>
+            </editorialgroup>
+        </bibdata>
+    </relation>
+    <relation type="partOf">
+        <bibdata type="standard">
+            <fetched>2018-11-09</fetched>
+            <title>Standardization documents -- Vocabulary</title>
+            <docidentifier>CC 36000</docidentifier>
+            <language></language>
+            <script></script>
+            <date type="">
+                <on>2018-10-25</on>
+            </date>
+            <status>proposal</status>
+            <editorialgroup>
+                <technical-committee>PUBLISH</technical-committee>
+            </editorialgroup>
+        </bibdata>
+    </relation>
 </relaton-collection>

--- a/spec/relaton/cli/relaton_file_spec.rb
+++ b/spec/relaton/cli/relaton_file_spec.rb
@@ -115,6 +115,26 @@ RSpec.describe Relaton::Cli::RelatonFile do
     end
   end
 
+  describe "split" do
+    before { FileUtils.mkdir_p("./tmp/output") }
+    after { FileUtils.rm_rf("./tmp/output") }
+
+    context "with valid collection and output dir" do
+      it "split the relaton collection into multiple files" do
+        output_dir = "./tmp/output"
+        collection_file = "spec/fixtures/sample-collection.xml"
+
+        Relaton::Cli::RelatonFile.split(collection_file, output_dir)
+        content = File.read([output_dir, "cc-34000.rxl"].join("/"))
+
+        expect(file_exist?("cc-34000.rxl")).to be true
+        expect(Dir["#{output_dir}/**"].length).to eq(7)
+        expect(content).to include("<bibdata type='standard'>")
+        expect(content).to include("<title>Date and time -- Concepts")
+      end
+    end
+  end
+
   def file_exist?(file, directory = "./tmp/output")
     File.exist?([directory, file].join("/"))
   end


### PR DESCRIPTION
This commit adds an interface that will allow us to split a relaton collection file into multiple files. This takes the collection file and the output directory as argument. Then it will split that file into multiple files and write it to the output directory.

By default it usages `rxl` extension for these new files, but we can also customize that by providing the correct one option.

```sh
relaton split Relaton-Collection-File Relaton-XML-Directory
```

Fixes: #33