### PR TITLE
Add support to convert single xml file

### DIFF
--- a/lib/relaton/cli/command.rb
+++ b/lib/relaton/cli/command.rb
@@ -48,7 +48,7 @@ module Relaton
         Relaton::Cli::YAMLConvertor.to_xml(filename, options)
       end
 
-      desc "xml2yaml XML", "Convert Relaton YAML into Relaton Bibcollection YAML (and separate files)"
+      desc "xml2yaml XML", "Convert Relaton XML into Relaton Bibdata / Bibcollection YAML (and separate files)"
       option :extension, aliases: :x, desc: "File extension of Relaton YAML files, defaults to 'yaml'"
       option :prefix, aliases: :p, desc: "Filename prefix of Relaton XML files, defaults to empty"
       option :outdir, aliases: :o, desc: "Output to the specified directory with individual Relaton Bibdata YAML files"

--- a/lib/relaton/cli/xml_convertor.rb
+++ b/lib/relaton/cli/xml_convertor.rb
@@ -30,7 +30,11 @@ module Relaton
       end
 
       def convert_content(content)
-        Relaton::Bibcollection.from_xml(content)
+        if content.root.name == "bibdata"
+          Bibdata.from_xml(content.to_s)
+        else
+          Bibcollection.from_xml(content)
+        end
       end
 
       def file_content

--- a/spec/fixtures/sample.rxl
+++ b/spec/fixtures/sample.rxl
@@ -1,4 +1,4 @@
-<bibdata xmlns="" type="standard">
+<bibdata xmlns="https://open.ribose.com/relaton-xml" type="standard">
 <title>Date and time -- Representations for information interchange -- Part 1: Basic rules</title>
 <uri>standards/csd-datetime-explict/csd-datetime-explict.xml</uri>
 <docidentifier>CC 18001</docidentifier>

--- a/spec/relaton/cli/xml_convertor_spec.rb
+++ b/spec/relaton/cli/xml_convertor_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe Relaton::Cli::XMLConvertor do
         expect(buffer.last).to include("title: Date and time -- Calendars")
       end
     end
+
+    context "with a single relaton file" do
+      it "converts the relaton xml file to yaml file" do
+        buffer = stub_file_write_to_io(sample_relaton_fille)
+        Relaton::Cli::XMLConvertor.to_yaml(sample_relaton_fille)
+
+        expect(buffer).to include("docidentifier: CC 18001")
+        expect(buffer).to include("doctype: standard")
+        expect(buffer).to include("uri: standards/csd-datetime-explict")
+      end
+    end
   end
 
   describe ".to_html" do
@@ -47,6 +58,10 @@ RSpec.describe Relaton::Cli::XMLConvertor do
         expect(buffer).to include("<title>CalConnect Standards Registry</tit")
       end
     end
+  end
+
+  def sample_relaton_fille
+    @sample_relaton_fille ||= "spec/fixtures/sample.rxl"
   end
 
   def sample_collection_file


### PR DESCRIPTION
Currently, the XML interface was only supporting a collection file and that's why we had to use this in some tricky way, this commit removes that limitation and now this interface supports both single / collection file.

Related: #29