### PR TITLE
Add option to ignore existing files

### DIFF
--- a/lib/relaton/cli/base_convertor.rb
+++ b/lib/relaton/cli/base_convertor.rb
@@ -11,6 +11,7 @@ module Relaton
         @options = options
         @outdir = options.fetch(:outdir, nil)
         @writable = options.fetch(:write, true)
+        @overwrite = options.fetch(:overwrite, true)
 
         install_dependencies(options[:require] || [])
       end
@@ -41,7 +42,7 @@ module Relaton
 
       private
 
-      attr_reader :file, :outdir, :options, :writable
+      attr_reader :file, :outdir, :options, :writable, :overwrite
 
       def default_ext
         raise "Override this method"
@@ -71,7 +72,10 @@ module Relaton
 
       def write_to_a_file(content, outfile = nil)
         outfile ||= Pathname.new(file).sub_ext(extension).to_s
-        File.open(outfile, "w:utf-8") { |file| file.write(content) }
+
+        if !File.exists?(outfile) || overwrite
+          File.open(outfile, "w:utf-8") { |file| file.write(content) }
+        end
       end
 
       def write_to_file_collection(content, format)

--- a/lib/relaton/cli/command.rb
+++ b/lib/relaton/cli/command.rb
@@ -43,6 +43,7 @@ module Relaton
       option :prefix, aliases: :p, desc: "Filename prefix of individual Relaton XML files, defaults to empty"
       option :outdir, aliases: :o,  desc: "Output to the specified directory with individual Relaton Bibdata XML files"
       option :require, aliases: :r, type: :array, desc: "Require LIBRARY prior to execution"
+      option :overwrite, aliases: :f, type: :boolean, default: false, desc: "Overwrite the existing file"
 
       def yaml2xml(filename)
         Relaton::Cli::YAMLConvertor.to_xml(filename, options)
@@ -53,6 +54,7 @@ module Relaton
       option :prefix, aliases: :p, desc: "Filename prefix of Relaton XML files, defaults to empty"
       option :outdir, aliases: :o, desc: "Output to the specified directory with individual Relaton Bibdata YAML files"
       option :require, aliases: :r, type: :array, desc: "Require LIBRARY prior to execution"
+      option :overwrite, aliases: :f, type: :boolean, default: false, desc: "Overwrite the existing file"
 
       def xml2yaml(filename)
         Relaton::Cli::XMLConvertor.to_yaml(filename, options)
@@ -61,6 +63,7 @@ module Relaton
       desc "xml2html RELATON-INDEX-XML", "Convert Relaton Collection XML into HTML"
       option :stylesheet, aliases: :s, desc: "Stylesheet file path for rendering HTML index"
       option :templatedir, aliases: :t, desc: "Liquid template directory for rendering Relaton items and collection"
+      option :overwrite, aliases: :f, type: :boolean, default: false, desc: "Overwrite the existing file"
 
       def xml2html(file, style = nil, template = nil)
         Relaton::Cli::XMLConvertor.to_html(file, style, template)
@@ -69,6 +72,7 @@ module Relaton
       desc "yaml2html RELATON-INDEX-YAML", "Concatenate Relaton Collection YAML into HTML"
       option :stylesheet, aliases: :s, desc: "Stylesheet file path for rendering HTML index"
       option :templatedir, aliases: :t, desc: "Liquid template directory for rendering Relaton items and collection"
+      option :overwrite, aliases: :f, type: :boolean, default: false, desc: "Overwrite the existing file"
 
       def yaml2html(file, style = nil, template = nil)
         Relaton::Cli::YAMLConvertor.to_html(file, style, template)

--- a/spec/acceptance/relaton_xml2yaml_spec.rb
+++ b/spec/acceptance/relaton_xml2yaml_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Relaton xml2yaml" do
         Relaton::Cli.start(command)
 
         expect(Relaton::Cli::XMLConvertor).to have_received(:to_yaml).
-          with("spec/fixtures/sample-collection.xml", {})
+          with("spec/fixtures/sample-collection.xml", { overwrite: false })
       end
     end
 
@@ -21,8 +21,12 @@ RSpec.describe "Relaton xml2yaml" do
         command = %w(xml2yaml spec/fixtures/sample.xml -x yaml -p RCL)
         Relaton::Cli.start(command)
 
-        expect(Relaton::Cli::XMLConvertor).to have_received(:to_yaml).
-          with("spec/fixtures/sample.xml", extension: "yaml", prefix: "RCL")
+        expect(Relaton::Cli::XMLConvertor).to have_received(:to_yaml).with(
+          "spec/fixtures/sample.xml",
+          extension: "yaml",
+          prefix: "RCL",
+          overwrite: false,
+        )
       end
     end
   end

--- a/spec/acceptance/relaton_yaml2xml_spec.rb
+++ b/spec/acceptance/relaton_yaml2xml_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Relaton yaml2xml" do
         Relaton::Cli.start(command)
 
         expect(Relaton::Cli::YAMLConvertor).to have_received(:to_xml).
-          with("spec/fixtures/sample.yaml", {})
+          with("spec/fixtures/sample.yaml", overwrite: false)
       end
     end
 
@@ -21,8 +21,12 @@ RSpec.describe "Relaton yaml2xml" do
         command = %w(yaml2xml spec/fixtures/sample.yaml -x rxml -p RCL)
         Relaton::Cli.start(command)
 
-        expect(Relaton::Cli::YAMLConvertor).to have_received(:to_xml).
-          with("spec/fixtures/sample.yaml", extension: "rxml", prefix: "RCL")
+        expect(Relaton::Cli::YAMLConvertor).to have_received(:to_xml).with(
+          "spec/fixtures/sample.yaml",
+          extension: "rxml",
+          prefix: "RCL",
+          overwrite: false,
+        )
       end
     end
   end


### PR DESCRIPTION
This commit adds support to overwrite / no-overwrite file during the conversion process. So, by default if the desire output file is already exists in the output directory then then it'll ignore that writing process. But, if we want to then we can force the rewrite using the `--overwrite` option with those command.

Related: #29