### PR TITLE
Fix document splitting in specified format

### DIFF
--- a/spec/relaton/cli/relaton_file_spec.rb
+++ b/spec/relaton/cli/relaton_file_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Relaton::Cli::RelatonFile do
         content = File.read([output_dir, "cc-34000.rxl"].join("/"))
 
         expect(file_exist?("cc-34000.rxl")).to be true
-        expect(Dir["#{output_dir}/**"].length).to eq(7)
+        expect(Dir["#{output_dir}/**"].length).to eq(6)
         expect(content).to include("<bibdata type='standard'>")
         expect(content).to include("<title>Date and time -- Concepts")
       end


### PR DESCRIPTION
The current `relaton split` interface only can parse a RXL/XML file and write to a variation of XML file (RXL / XML) file, but the problem arises when we define `yaml` as output extension, then it still writes
the XML content, but usages YAML for file name only. This cases to new problems.

So, this commit fixes these issues, so now it will check for the output format first, and if it's different than XML then it will parse the content to that format first and then write it to the new file.

This interface also used to write the collection file in the output directory, which introduced some issues like #41, so this commit also disables that for now.

Another thing, it also updates the build_filename method to remove all of the invalid characters from a file name.